### PR TITLE
Initialize secret storage and add wasm fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Matrix crypto WASM
+public/matrix_sdk_crypto_bg.wasm

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ This template should help get you started developing with Vue 3 in Vite. The tem
 
 Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://vuejs.org/guide/scaling-up/tooling.html#ide-support).
 # yhl_demo
+
+## Crypto WASM file
+Copy `node_modules/@matrix-org/matrix-sdk-crypto-wasm/pkg/matrix_sdk_crypto_wasm_bg.wasm` to `public/matrix_sdk_crypto_bg.wasm` before building. This file is required for end-to-end encryption and is ignored by git.

--- a/src/api/matrix.js
+++ b/src/api/matrix.js
@@ -2,9 +2,34 @@
  * src/api/matrix.js
  * ----------------------------------------------------- */
 import * as sdk from "matrix-js-sdk";
+import * as RustCrypto from "@matrix-org/matrix-sdk-crypto-wasm";
 import { useSessionStore } from "../store/session";
 import { useRoomStore } from "../store/rooms";
 import { useCallStore } from "../store/call";
+
+import { RECOVERY_PHRASE, decodeRecoveryPhrase } from "./recovery";
+// fallback for incorrect wasm MIME types
+if (WebAssembly && WebAssembly.instantiateStreaming) {
+  const orig = WebAssembly.instantiateStreaming;
+  WebAssembly.instantiateStreaming = async (src, importObject) => {
+    try {
+      return await orig(src, importObject);
+    } catch (e) {
+      const resp = await src;
+      const bytes = await resp.arrayBuffer();
+      return await WebAssembly.instantiate(bytes, importObject);
+    }
+  };
+}
+
+// load the crypto wasm module from the public folder
+let wasmInit;
+export function loadCryptoWasm() {
+  if (!wasmInit) {
+    wasmInit = RustCrypto.initAsync("/matrix_sdk_crypto_bg.wasm");
+  }
+  return wasmInit;
+}
 
 /**
  * 给 MatrixClient 绑定统一事件监听：
@@ -35,6 +60,7 @@ export function setupClient(client) {
     call.on("state", () => callStore.updateState(call.state));
     // 音视频流变化
     call.on("feeds_changed", () => rooms.ping());
+    call.on("hangup", () => callStore.$reset());
   });
 }
 
@@ -61,7 +87,25 @@ export async function loginHomeserver({ baseUrl, user, password }) {
     accessToken: res.access_token,
     userId: res.user_id,
     deviceId: res.device_id,
+    cryptoCallbacks: {
+      // 使用固定助记词自动解锁密钥库，正式环境应改为交互式输入
+      getSecretStorageKey: async ({ keys }) => {
+        const keyId = Object.keys(keys)[0];
+        return [keyId, decodeRecoveryPhrase()];
+      },
+    },
   });
+
+  // --- initialize rust crypto for end-to-end encryption ---
+  await loadCryptoWasm();
+  await client.initRustCrypto();
+  await ensureEncryptionSetup(client);
+  // 请求主设备确认以完成信任验证
+  try {
+    await client.getCrypto().requestOwnUserVerification();
+  } catch {
+    /* ignore */
+  }
 
   setupClient(client);
   client.startClient({ initialSyncLimit: 20, pollTimeout: 10000 });
@@ -143,6 +187,7 @@ export async function placeVideoCall(roomId) {
   // 状态监听
   call.on("state", () => callStore.updateState(call.state));
   call.on("feeds_changed", () => rooms.ping());
+  call.on("hangup", () => callStore.$reset());
 
   await call.placeVideoCall();
 }
@@ -161,4 +206,32 @@ export async function logout() {
   ["baseUrl", "userId", "accessToken", "deviceId"].forEach((k) =>
     localStorage.removeItem(k)
   );
+}
+
+/* -------------------------------------------------------
+ * 加密辅助：初始化密钥和交叉签名
+ * ----------------------------------------------------- */
+export async function ensureEncryptionSetup(client) {
+  const crypto = client.getCrypto();
+  await crypto.bootstrapSecretStorage({
+    // 自动创建密钥库，使用上方常量作为恢复短语
+    createSecretStorageKey: async () => {
+      return crypto.createRecoveryKeyFromPassphrase(RECOVERY_PHRASE);
+    },
+  });
+
+  await crypto.bootstrapCrossSigning({
+    authUploadDeviceSigningKeys: async (makeRequest) => makeRequest({}),
+  });
+
+  const hasBackup = (await crypto.checkKeyBackupAndEnable()) !== null;
+  if (!hasBackup) await crypto.resetKeyBackup();
+}
+
+/* -------------------------------------------------------
+ * 向主设备发送验证请求
+ * ----------------------------------------------------- */
+export function requestVerificationFromMobile() {
+  const { client } = useSessionStore();
+  return client.getCrypto().requestOwnUserVerification();
 }

--- a/src/api/recovery.js
+++ b/src/api/recovery.js
@@ -1,0 +1,9 @@
+import { decodeRecoveryKey } from "matrix-js-sdk/lib/crypto-api/recovery-key";
+
+// 固定助记词（仅供测试）
+export const RECOVERY_PHRASE =
+  "EsUG BNSP HxK6 SM9j EHPk SsSE UW4r 238h Bz97 rtJ3 RfGZ JUb2";
+
+export function decodeRecoveryPhrase() {
+  return decodeRecoveryKey(RECOVERY_PHRASE);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,8 @@ import "element-plus/dist/index.css";
 import router from "./router";
 import App from "./App.vue";
 import * as sdk from "matrix-js-sdk";
-import { setupClient } from "./api/matrix";
+import { setupClient, ensureEncryptionSetup, loadCryptoWasm } from "./api/matrix";
+import { decodeRecoveryPhrase } from "./api/recovery";
 import { useSessionStore } from "./store/session";
 
 // -------- 自动恢复 Matrix 会话 ----------
@@ -20,9 +21,26 @@ app.use(ElementPlus);
 app.use(router);
 
 if (baseUrl && accessToken && userId) {
-  const client = sdk.createClient({ baseUrl, accessToken, userId, deviceId });
+  const client = sdk.createClient({
+    baseUrl,
+    accessToken,
+    userId,
+    deviceId,
+    cryptoCallbacks: {
+      // 测试环境中直接使用固定助记词解锁密钥库
+      getSecretStorageKey: async ({ keys }) => {
+        const keyId = Object.keys(keys)[0];
+        return [keyId, decodeRecoveryPhrase()];
+      },
+    },
+  });
   setupClient(client); // ← 同一监听
-  client.startClient({ initialSyncLimit: 20, pollTimeout: 10000 });
+  loadCryptoWasm()
+    .then(() => client.initRustCrypto())
+    .then(async () => {
+      await ensureEncryptionSetup(client);
+      client.startClient({ initialSyncLimit: 20, pollTimeout: 10000 });
+    });
 
   useSessionStore().setClient(client);
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,4 +10,5 @@ export default defineConfig({
     AutoImport({ resolvers: [ElementPlusResolver()] }),
     Components({ resolvers: [ElementPlusResolver()] }),
   ],
+  assetsInclude: ["**/*.wasm"],
 });


### PR DESCRIPTION
## Summary
- add fallback for WebAssembly.instantiateStreaming
- request secret storage key and set up key backup/cross signing
- setup encryption when restoring sessions
- use a fixed recovery phrase for testing
- share recovery phrase helper
- reset call store on hangup and auto request verification on login
- load matrix crypto wasm from public folder
- include wasm file as asset and load before enabling rust crypto
- ignore `public/matrix_sdk_crypto_bg.wasm` and document how to obtain it

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e3cd116288333bb50048c094d67c3