### PR TITLE
Add matrix call event integration

### DIFF
--- a/src/api/matrix.js
+++ b/src/api/matrix.js
@@ -192,10 +192,11 @@ export async function placeVideoCall(roomId) {
   const link = `https://meeting.yhlcps.com/${roomName}`;
 
   // 发送 Element 风格的通话事件，携带 Jitsi 信息
+  const callId = "jitsi-" + Date.now();
   await session.client.sendEvent(
     roomId,
     "m.call.invite",
-    { roomName, link },
+    { roomName, link, call_id: callId, version: 1 },
     ""
   );
 

--- a/src/api/matrix.js
+++ b/src/api/matrix.js
@@ -52,8 +52,8 @@ export function setupClient(client) {
       ev.getType() === "m.call.invite" &&
       ev.getSender() !== session.userId
     ) {
-      const { roomName } = ev.getContent() || {};
-      if (roomName) callStore.prepare(roomName, true);
+      const { roomName, call_id } = ev.getContent() || {};
+      if (roomName) callStore.prepare(roomName, true, call_id);
     }
   });
 
@@ -193,15 +193,19 @@ export async function placeVideoCall(roomId) {
 
   // 发送 Element 风格的通话事件，携带 Jitsi 信息
   const callId = "jitsi-" + Date.now();
-  await session.client.sendEvent(
-    roomId,
-    "m.call.invite",
-    { roomName, link, call_id: callId, version: 1 },
-    ""
-  );
+  const content = {
+    roomName,
+    link,
+    call_id: callId,
+    version: "1",
+    party_id: session.client.getDeviceId(),
+    lifetime: 60000,
+    offer: { sdp: "", type: "offer" },
+  };
+  await session.client.sendEvent(roomId, "m.call.invite", content, "");
 
   // 准备通话
-  callStore.prepare(roomName);
+  callStore.prepare(roomName, false, callId);
 }
 
 /**

--- a/src/api/matrix.js
+++ b/src/api/matrix.js
@@ -53,7 +53,7 @@ export function setupClient(client) {
       ev.getSender() !== session.userId
     ) {
       const { roomName } = ev.getContent() || {};
-      if (roomName) callStore.prepare(roomName);
+      if (roomName) callStore.prepare(roomName, true);
     }
   });
 

--- a/src/components/CallLayer.vue
+++ b/src/components/CallLayer.vue
@@ -24,9 +24,12 @@
 <script setup>
 import { ref, watch, nextTick } from 'vue';
 import { Phone, Microphone, VideoCamera } from '@element-plus/icons-vue';
+import { ElMessageBox } from 'element-plus';
 import { useCallStore } from '../store/call';
+import { useSessionStore } from '../store/session';
 
 const callStore = useCallStore();
+const session = useSessionStore();
 const visible = ref(false);
 const container = ref(null);
 
@@ -35,8 +38,19 @@ watch(
   async (s) => {
     visible.value = s !== 'idle';
     if (s === 'pending') {
+      if (callStore.incoming) {
+        try {
+          await ElMessageBox.confirm('是否接听来电?', '视频通话', {
+            confirmButtonText: '接听',
+            cancelButtonText: '拒绝',
+          });
+        } catch {
+          callStore.hangup();
+          return;
+        }
+      }
       await nextTick();
-      callStore.start(container.value);
+      callStore.start(container.value, session.userId);
     }
   }
 );

--- a/src/components/MessageItem.vue
+++ b/src/components/MessageItem.vue
@@ -15,12 +15,15 @@
     </el-card>
 
     <!-- 文件 -->
-    <el-card v-else class="card file">
+    <el-card v-else-if="isFile" class="card file">
       <div>{{ content.body }} ({{ prettySize }})</div>
       <template #footer>
         <el-button link @click="download">下载</el-button>
       </template>
     </el-card>
+
+    <!-- 原始消息 -->
+    <div v-else class="bubble raw">{{ rawJson }}</div>
   </div>
 </template>
 
@@ -37,7 +40,9 @@ const isMe = props.event.getSender() === session.userId;
 const isText = content.msgtype === "m.text";
 const failed = props.event.status === "not_sent";
 const isImage = content.msgtype === "m.image";
+const isFile = content.msgtype === "m.file";
 const isCallInvite = props.event.getType() === "m.call.invite";
+const rawJson = JSON.stringify(props.event.event);
 
 const mxcUrl = computed(() =>
   // session.client.mxcUrlToHttp(content.url, 300, 300, "scale")
@@ -81,6 +86,10 @@ async function download() {
   color: #fff;
   padding: 8px 16px;
   border-radius: 6px;
+}
+.raw {
+  word-break: break-all;
+  font-family: monospace;
 }
 .card {
   max-width: 200px;

--- a/src/components/MessageItem.vue
+++ b/src/components/MessageItem.vue
@@ -3,6 +3,9 @@
     <!-- 文本 -->
     <div v-if="isText" class="bubble">{{ content.body }}</div>
 
+    <!-- 通话邀请 -->
+    <div v-else-if="isCallInvite" class="bubble">[视频通话邀请]</div>
+
     <!-- 图片 -->
     <el-card v-else-if="isImage" class="card">
       <el-image :src="mxcUrl" fit="cover" style="width: 150px; height: 150px" />
@@ -34,6 +37,7 @@ const isMe = props.event.getSender() === session.userId;
 const isText = content.msgtype === "m.text";
 const failed = props.event.status === "not_sent";
 const isImage = content.msgtype === "m.image";
+const isCallInvite = props.event.getType() === "m.call.invite";
 
 const mxcUrl = computed(() =>
   // session.client.mxcUrlToHttp(content.url, 300, 300, "scale")

--- a/src/store/call.js
+++ b/src/store/call.js
@@ -5,18 +5,21 @@ export const useCallStore = defineStore("call", {
     api: null, // JitsiMeetExternalAPI instance
     state: "idle", // idle | pending | connected
     roomName: "",
+    incoming: false,
   }),
   actions: {
-    prepare(roomName) {
+    prepare(roomName, incoming = false) {
       this.roomName = roomName;
+      this.incoming = incoming;
       this.state = "pending";
     },
-    start(parentNode) {
+    start(parentNode, displayName) {
       if (!this.roomName) return;
       const domain = "meeting.yhlcps.com";
       this.api = new window.JitsiMeetExternalAPI(domain, {
         roomName: this.roomName,
         parentNode,
+        userInfo: { displayName },
         iframeAttrs: {
           allow: "camera; microphone; fullscreen; display-capture",
         },

--- a/src/store/call.js
+++ b/src/store/call.js
@@ -5,11 +5,13 @@ export const useCallStore = defineStore("call", {
     api: null, // JitsiMeetExternalAPI instance
     state: "idle", // idle | pending | connected
     roomName: "",
+    callId: "",
     incoming: false,
   }),
   actions: {
-    prepare(roomName, incoming = false) {
+    prepare(roomName, incoming = false, callId = "") {
       this.roomName = roomName;
+      this.callId = callId;
       this.incoming = incoming;
       this.state = "pending";
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,8 @@ export default defineConfig({
   assetsInclude: ["**/*.wasm"],
   resolve: {
     conditions: ["wasm"],
+    dedupe: ["matrix-js-sdk"],
   },
+  optimizeDeps: { include: ["matrix-js-sdk"] },
   server: { https: true },
 });


### PR DESCRIPTION
## Summary
- handle incoming `m.call.invite` events and start Jitsi call
- send Jitsi info via `m.call.invite` when placing a call

## Testing
- `npm install`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68825a80de608333a78d0d59a41f763f