### PR TITLE
Fix TreeSidebar navigation path

### DIFF
--- a/src/components/TreeSidebar.vue
+++ b/src/components/TreeSidebar.vue
@@ -25,7 +25,7 @@ onMounted(async () => {
 function onClick(data, node) {
   const segments = []
   let n = node
-  while (n && n.level > 1) {
+  while (n && n.level >= 1) {
     segments.unshift({ type: n.data.type, label: n.data.label })
     n = n.parent
   }


### PR DESCRIPTION
## Summary
- include workspace level when building paths in sidebar

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68828e90d8448333bef014a194f3b743