### PR TITLE
Add default login account dropdown

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -4,6 +4,12 @@
       <el-form-item label="Homeserver">
         <el-input v-model="hs" placeholder="https://matrix.org" />
       </el-form-item>
+      <el-form-item label="选择账户">
+        <el-select v-model="selectedAccount" placeholder="请选择账户" @change="applyAccount">
+          <el-option label="drop" value="drop" />
+          <el-option label="bot" value="bot" />
+        </el-select>
+      </el-form-item>
       <el-form-item label="用户名">
         <el-input v-model="user" placeholder="@user:example.com" />
       </el-form-item>
@@ -25,9 +31,20 @@ import { loginHomeserver } from "../api/matrix";
 // const hs = ref("https://nsynapse.lexon.tq.i3s.io"); // 示例
 // const user = ref("@drop:nr.lexon.tq.i3s.io");
 const hs = ref("https://synapse.m2m.yhlcps.com");
-const user = ref("@drop:m2m.yhlcps.com");
-const pwd = ref("TQcps@123_");
+const accounts = {
+  drop: "@drop:m2m.yhlcps.com",
+  bot: "@bot:m2m.yhlcps.com",
+};
+const defaultPassword = "TQcps@123_";
+const selectedAccount = ref("drop");
+const user = ref(accounts[selectedAccount.value]);
+const pwd = ref(defaultPassword);
 const rt = useRouter();
+
+function applyAccount(name) {
+  user.value = accounts[name];
+  pwd.value = defaultPassword;
+}
 
 async function onLogin() {
   await loginHomeserver({


### PR DESCRIPTION
## Summary
- add Element Plus dropdown for choosing default account
- preset bot and drop accounts with shared password

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a143c9a008333ba77f7ce0135ba7b